### PR TITLE
Guard the external link launch in the local web view

### DIFF
--- a/twa/app/src/main/java/com/ciphernotes/twa/LocalWebViewActivity.java
+++ b/twa/app/src/main/java/com/ciphernotes/twa/LocalWebViewActivity.java
@@ -217,7 +217,11 @@ public class LocalWebViewActivity extends AppCompatActivity {
           return false;
         }
         Intent external = new Intent(Intent.ACTION_VIEW, uri);
-        startActivity(external);
+        try {
+            startActivity(external);
+        } catch (ActivityNotFoundException e) {
+            Toast.makeText(v.getContext(), "No app found to open this link", Toast.LENGTH_SHORT).show();
+        }
         return true;
       }
     });


### PR DESCRIPTION
This wraps the external link launch in the local web view so the app no longer crashes when there is no app available to open the link.

Before, external links were passed to `startActivity` directly, which throws `ActivityNotFoundException` on a device with no handler. With this change the link still opens when a handler exists, and otherwise the exception is caught and a short message is shown.

Closes #5.